### PR TITLE
IE11 has problems with triggering the load function ( one ) if image …

### DIFF
--- a/src/jquery.responsiveImage.js
+++ b/src/jquery.responsiveImage.js
@@ -211,7 +211,7 @@
             }
 
             // add load event listener and set image source
-            $image.one('load', function() {
+            $image.on('load', function() {
                 self.$element.trigger('load.source.responsiveImage');
 
                 // append responsive image to target element after preload

--- a/src/jquery.responsiveImage.js
+++ b/src/jquery.responsiveImage.js
@@ -218,6 +218,8 @@
                 if( self.options.preload ) {
                     self.setNewSource( $image );
                 }
+
+                $image.off('load');
             })
             .attr('src', source.src);
 


### PR DESCRIPTION
…is cached.

I'm not exactly sure why this is happening. Couldn't find anything regarding problems with JQuery one() function and IE11 or an IE11 issue with events which can be fired only once.

However changing to on() function fixes this issue for me.